### PR TITLE
Relax haskell-src-meta bounds

### DIFF
--- a/here.cabal
+++ b/here.cabal
@@ -26,7 +26,7 @@ library
     Data.String.Here.Internal
   build-depends:
     base >= 4.5 && < 4.10,
-    haskell-src-meta ==0.6.*,
+    haskell-src-meta >= 0.6 && < 0.8,
     mtl >=2.1 && < 2.3,
     parsec ==3.1.*,
     template-haskell


### PR DESCRIPTION
Tested with stackage nightly-2016-10-18, which has haskell-src-meta-0.7.0.