### PR TITLE
Bump haskell-src-meta upperbound

### DIFF
--- a/here.cabal
+++ b/here.cabal
@@ -26,7 +26,7 @@ library
     Data.String.Here.Internal
   build-depends:
     base >= 4.5 && < 4.10,
-    haskell-src-meta >= 0.6 && < 0.8,
+    haskell-src-meta >= 0.6 && < 0.9,
     mtl >=2.1 && < 2.3,
     parsec ==3.1.*,
     template-haskell


### PR DESCRIPTION
I tested that everything still compiles but I have to admit that I haven’t run any tests.