### PR TITLE
Fix infinite loop with ${}

### DIFF
--- a/src/Data/String/Here/Interpolated.hs
+++ b/src/Data/String/Here/Interpolated.hs
@@ -86,7 +86,7 @@ p_interp :: Parser [StringPart]
 p_interp = manyTill p_stringPart eof
 
 p_stringPart :: Parser StringPart
-p_stringPart = try p_anti <|> p_esc <|> p_lit
+p_stringPart = p_anti <|> p_esc <|> p_lit
 
 p_anti :: Parser StringPart
 p_anti = Anti <$> between p_antiOpen p_antiClose p_antiExpr


### PR DESCRIPTION
Prior to this commit, the quasiquotation `[i|${}]` would cause an infinite loop
and eat all your RAM. It was parsing it as an infinite list of `Lit []`. This
change removes the `try` around `p_anti`, which causes the parser to commit to
`p_anti` as soon as it sees an unescaped '$' character. When `p_anti` fails, the
whole parse fails.