### PR TITLE
here.cabal: relax constraint on base to support GHC 8.4.x

### DIFF
--- a/here.cabal
+++ b/here.cabal
@@ -25,7 +25,7 @@ library
   other-modules:
     Data.String.Here.Internal
   build-depends:
-    base >= 4.5 && < 4.11,
+    base >= 4.5 && < 5,
     haskell-src-meta >= 0.6 && < 0.9,
     mtl >=2.1 && < 2.3,
     parsec ==3.1.*,


### PR DESCRIPTION
`here` works fine with GHC 8.4.x once the `base` constraint is relaxed.