### PR TITLE
Add iTrimMargins

### DIFF
--- a/src/Data/String/Here/Interpolated.hs
+++ b/src/Data/String/Here/Interpolated.hs
@@ -2,12 +2,13 @@
 {-# OPTIONS_GHC -fno-warn-missing-fields #-}
 
 -- | Interpolated here docs
-module Data.String.Here.Interpolated (i, iTrim, template) where
+module Data.String.Here.Interpolated (i, iTrim, iTrimMargins, template) where
 
 import Control.Applicative hiding ((<|>))
 import Control.Monad.State
 
 import Data.Char
+import Data.List
 import Data.Maybe
 import Data.Monoid
 import Data.String
@@ -50,6 +51,21 @@ i = QuasiQuoter {quoteExp = quoteInterp}
 -- | Like 'i', but with leading and trailing whitespace trimmed
 iTrim :: QuasiQuoter
 iTrim = QuasiQuoter {quoteExp = quoteInterp . trim}
+
+-- | Like 'iTrim', but every lines's leading and trailing whiltespace trimmed
+iTrimMargins :: QuasiQuoter
+iTrimMargins = QuasiQuoter {quoteExp = quoteInterp . trimMargins}
+  where
+    removeLeading = map $ dropWhile (== ' ')
+    reverseLines = map reverse
+
+    unlines' = mconcat . intersperse "\n"
+
+    trimMargins x =
+      let xs = lines x
+          remainTrail = removeLeading xs
+          trimmed = reverseLines . removeLeading $ reverseLines remainTrail
+      in unlines' $ filter (/= "") trimmed
 
 -- | Quote the contents of a file as with 'i'
 --

--- a/test/Data/String/HereSpec.hs
+++ b/test/Data/String/HereSpec.hs
@@ -54,6 +54,17 @@ spec = do
           actual = [i|value is ${val1}|]
       actual `shouldBe` expect
 
+  describe "iTrimMargins quote" $ do
+    it "should trim leading whiltespaces" $ do
+      let expected :: String
+          expected = "Hi\n:D"
+          actual :: String
+          actual = [iTrimMargins|
+            Hi
+            :D
+          |]
+      actual `shouldBe` expected
+
   -- (from: https://github.com/tmhedberg/here#readme)
   describe "here quote" $ do
     it "should be here docs" $ do


### PR DESCRIPTION
Hi, I'm a `here` user :D

I added `iTrimMargins`, it removes leading and trailing spaces from **every lines**.

```haskell
let x = [iTrimMargins|
    10
    20
]
x == "10\n20"
```

I often needed this, please merge this :dog2: