### PR TITLE
fix: `import Control.Monad` because `unless`

### DIFF
--- a/src/Data/String/Here/Interpolated.hs
+++ b/src/Data/String/Here/Interpolated.hs
@@ -5,6 +5,7 @@
 module Data.String.Here.Interpolated (i, iTrim, template) where
 
 import Control.Applicative hiding ((<|>))
+import Control.Monad
 import Control.Monad.State
 
 import Data.Char


### PR DESCRIPTION
support recent GHC and base.