### PR TITLE
build: add `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle


### PR DESCRIPTION
I excluded the `dist-newstyle` directory in the `.gitignore` file because the newer version of Cabal automatically creates it, which can make git operations cumbersome during development.