### PR TITLE
build: allow mtl 2.3.x

### DIFF
--- a/here.cabal
+++ b/here.cabal
@@ -27,7 +27,7 @@ library
   build-depends:
     base >= 4.5 && < 5,
     haskell-src-meta >= 0.6 && < 0.9,
-    mtl >=2.1 && < 2.3,
+    mtl >=2.1 && < 2.4,
     parsec ==3.1.*,
     template-haskell
   ghc-options: -Wall


### PR DESCRIPTION
I have updated the version constraints to support the mtl-2.3 series, specifically mtl-2.3.1. As far as I can confirm, there are no breaking changes that would affect this package.