### PR TITLE
here.cabal: include hspec-discover as build tool

### DIFF
--- a/here.cabal
+++ b/here.cabal
@@ -38,6 +38,8 @@ test-suite here-test
   main-is: Spec.hs
   hs-source-dirs:
     test
+  build-tool-depends:
+    hspec-discover:hspec-discover
   build-depends:
     base >=4.5 && <5,
     here,


### PR DESCRIPTION
It is technically required to run the tests.